### PR TITLE
feat: add `error.cause` to exception report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 _Forked from https://github.com/robertcepa/toucan-js_
 
 _All credit and fixes should be directed there_

--- a/src/index.ts
+++ b/src/index.ts
@@ -568,7 +568,7 @@ export default class Toucan {
    * @param event
    * @param error
    */
-  private async reportException(event: Event, maybeError: unknown) {
+  private async reportException(event: Event, maybeError: unknown): Promise<Response> {
     let error: Error;
 
     if (isError(maybeError)) {
@@ -591,11 +591,19 @@ export default class Toucan {
     }
 
     const stacktrace = await this.buildStackTrace(error);
-    event.exception = {
-      values: [{ type: error.name, value: error.message, stacktrace }],
-    };
+    
+    const values = event.exception?.values ?? []
+    if (!event.exception?.values) {
+      event.exception = { values }
+    }
+    // push cause on to the top
+    values.unshift({ type: error.name, value: error.message, stacktrace })
 
-    return this.postEvent(event);
+    if (error.cause) {
+      return this.reportException(event, error.cause)
+    } else {
+      return this.postEvent(event);
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -568,7 +568,10 @@ export default class Toucan {
    * @param event
    * @param error
    */
-  private async reportException(event: Event, maybeError: unknown): Promise<Response> {
+  private async reportException(
+    event: Event,
+    maybeError: unknown
+  ): Promise<Response> {
     let error: Error;
 
     if (isError(maybeError)) {
@@ -591,16 +594,16 @@ export default class Toucan {
     }
 
     const stacktrace = await this.buildStackTrace(error);
-    
-    const values = event.exception?.values ?? []
+
+    const values = event.exception?.values ?? [];
     if (!event.exception?.values) {
-      event.exception = { values }
+      event.exception = { values };
     }
     // push cause on to the top
-    values.unshift({ type: error.name, value: error.message, stacktrace })
+    values.unshift({ type: error.name, value: error.message, stacktrace });
 
     if (error.cause) {
-      return this.reportException(event, error.cause)
+      return this.reportException(event, error.cause);
     } else {
       return this.postEvent(event);
     }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -214,6 +214,70 @@ Object {
 
 exports[`Toucan FetchEvent captureException: Error 2`] = `"651b177fe1cb4ac89e15c1ecd2cb1d0a"`;
 
+exports[`Toucan FetchEvent captureException: Error with cause 1`] = `
+Object {
+  "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
+  "exception": Object {
+    "values": Array [
+      Object {
+        "stacktrace": Object {
+          "frames": Array [
+            Object {
+              "colno": 0,
+              "filename": "~/file",
+              "function": "bar",
+              "lineno": 0,
+            },
+            Object {
+              "colno": 0,
+              "filename": "~/file",
+              "function": "foo",
+              "lineno": 0,
+            },
+          ],
+        },
+        "type": "Error",
+        "value": "original error",
+      },
+      Object {
+        "stacktrace": Object {
+          "frames": Array [
+            Object {
+              "colno": 0,
+              "filename": "~/file",
+              "function": "bar",
+              "lineno": 0,
+            },
+            Object {
+              "colno": 0,
+              "filename": "~/file",
+              "function": "foo",
+              "lineno": 0,
+            },
+          ],
+        },
+        "type": "Error",
+        "value": "outer error with cause",
+      },
+    ],
+  },
+  "level": "error",
+  "logger": "EdgeWorker",
+  "platform": "node",
+  "request": Object {
+    "method": "GET",
+    "url": "https://example.com/",
+  },
+  "sdk": Object {
+    "name": "__name__",
+    "version": "__version__",
+  },
+  "timestamp": 1586752837.868,
+}
+`;
+
+exports[`Toucan FetchEvent captureException: Error with cause 2`] = `"651b177fe1cb4ac89e15c1ecd2cb1d0a"`;
+
 exports[`Toucan FetchEvent captureException: Object 1`] = `
 Object {
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -201,7 +201,7 @@ describe('Toucan', () => {
           try {
             throw new Error('original error');
           } catch (cause) {
-            throw new Error('outer error with cause', {cause})
+            throw new Error('outer error with cause', { cause });
           }
         } catch (e) {
           result = toucan.captureException(e);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -189,6 +189,38 @@ describe('Toucan', () => {
       expect(result).toMatchSnapshot();
     });
 
+    test('captureException: Error with cause', async () => {
+      let result: string | undefined = undefined;
+      self.addEventListener('fetch', (event) => {
+        const toucan = new Toucan({
+          dsn: VALID_DSN,
+          event,
+        });
+
+        try {
+          try {
+            throw new Error('original error');
+          } catch (cause) {
+            throw new Error('outer error with cause', {cause})
+          }
+        } catch (e) {
+          result = toucan.captureException(e);
+        }
+
+        event.respondWith(new Response('OK', { status: 200 }));
+      });
+
+      // Trigger fetch event defined above
+      await triggerFetchAndWait(self);
+
+      // Expect POST request to Sentry
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      // Match POST request payload snap
+      expect(getFetchMockPayload(global.fetch)).toMatchSnapshot();
+      // captureException should have returned a generated eventId
+      expect(result).toMatchSnapshot();
+    });
+
     test('captureException: Object', async () => {
       let result: string | undefined = undefined;
       self.addEventListener('fetch', (event) => {


### PR DESCRIPTION
Tweaks `reportException` to recursively handle nested Errors it finds in the `cause` property.

The Errors are reported with the most nested `cause` first in the exception.values array as per the "chained exceptions" example: https://develop.sentry.dev/sdk/event-payloads/exception/

see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause

_ported from https://github.com/robertcepa/toucan-js/pull/104 so we can publish it get those causes sent to sentry._

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>